### PR TITLE
change url for return link

### DIFF
--- a/src/_includes/layouts/talk.njk
+++ b/src/_includes/layouts/talk.njk
@@ -35,7 +35,7 @@ layout: layouts/base.njk
     {% endfor %}
   {% endif %}
 
-  <a class="td-blog__back" href="/blog">Back to all posts</a>
+  <a class="td-blog__back" href="/talks">Back to all talks</a>
 
   {% if canonical %}
   <small class="thought-canonical">This post originally appeared at:<br /><a href="{{ canonical }}">{{ canonical }}<a/></small>


### PR DESCRIPTION
The link at the bottom of the page would take use to the blog post listing page instead of the talks listing page. 