### PR TITLE
ref #49 - enable openssl-legacy-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "eleventy --serve",
-    "build": "ELEVENTY_ENV=production eleventy"
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider;ELEVENTY_ENV=production eleventy"
   },
   "author": "Vincent Tang",
   "license": "ISC",


### PR DESCRIPTION
ref #49 

node 17, unlike previous versions, uses OpenSSL3. This changes the initialization context for md hashing algorithms (used in webpack@4).

enabling openssl-legacy-provider resolves the issue