### PR TITLE
Added hover styling to social icons and fixed alt tag for whatsapp

### DIFF
--- a/src/_assets/scss/_nav.scss
+++ b/src/_assets/scss/_nav.scss
@@ -85,6 +85,12 @@
   .social-icon {
     height: 14px;
   }
+
+  .social-icon:hover {
+    opacity: 70%;
+    transition: all 0.3s;
+  }
+
 }
 
 @media (max-width: 600px) {

--- a/src/_assets/scss/style.scss
+++ b/src/_assets/scss/style.scss
@@ -327,6 +327,10 @@ a:focus {
   width: auto;
 }
 
+.td-footer__social img:hover {
+  opacity: 70%;
+}
+
 .td-newsletter {
   background-color: $colorOrange;
   color: white;

--- a/src/_includes/blocks/footer.njk
+++ b/src/_includes/blocks/footer.njk
@@ -48,7 +48,7 @@
       <li><a href="https://www.meetup.com/tampadevs" target="_blank" rel="noopener"><img class="social-icon" src="/_assets/misc/icons/meetup.svg" alt="Meetup"/></a></li>
       <li><a href="https://go.tampa.dev/slack" target="_blank" rel="noopener"><img class="social-icon" src="/_assets/misc/icons/slack.svg" alt="Slack"/></a></li>
       <li><a href="mailto:hello@tampadevs.com" target="_blank" rel="noopener"><img class="social-icon" src="/_assets/misc/icons/gmail.png" alt="Gmail"/></a></li>
-      <li><a href="https://chat.whatsapp.com/IcKV07RiAkABm0MIUJhcIw" target="_blank" rel="noopener"><img class="social-icon" src="/_assets/misc/icons/whatsapp.svg" alt="Gmail"/></a></li>
+      <li><a href="https://chat.whatsapp.com/IcKV07RiAkABm0MIUJhcIw" target="_blank" rel="noopener"><img class="social-icon" src="/_assets/misc/icons/whatsapp.svg" alt="WhatsApp"/></a></li>
     </ul>
   </div>
   <p>


### PR DESCRIPTION
Basically just put an opacity of 70% on the social icon when you hover to click.

Before:
Navbar:
<img width="209" alt="Screenshot 2023-08-16 at 2 08 14 AM" src="https://github.com/TampaDevs/tampadevs/assets/112845092/47611a04-dd2b-4e66-a7a3-ab3bc82e0e66">

Footer:
<img width="1038" alt="Screenshot 2023-08-16 at 2 09 01 AM" src="https://github.com/TampaDevs/tampadevs/assets/112845092/d19374c5-5c40-4d5e-955b-676d2a0e146e">


After:
Navbar:
<img width="267" alt="Screenshot 2023-08-16 at 2 07 02 AM" src="https://github.com/TampaDevs/tampadevs/assets/112845092/a510b547-ba5a-4c7c-84fd-bafee8465905">

Footer:
<img width="998" alt="Screenshot 2023-08-16 at 2 07 25 AM" src="https://github.com/TampaDevs/tampadevs/assets/112845092/09a8962f-50b5-4006-a912-7b0a4b9421a9">

