### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:alpine3.17
+
+WORKDIR /app
+
+COPY package*.json /app
+
+RUN npm add -g npm @11ty/eleventy
+RUN npm install
+
+ENTRYPOINT ["npm", "run", "dev"]

--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,17 @@ This project currently uses Node version 17.9.1 as the preferred environment
 
 The easiest way to run a development environment for this site is to use [Docker](https://www.docker.com/).
 
-After installing Docker on your machine, run the following command to spin up a container with a functional Eleventy environment:
+After installing Docker on your machine, run the following command from the root of this repo to build the docker image
 
 ```
-docker run --rm -v /path-to/this-repo/on-your/disk:/app --name eleventy -p 8080:8080 femtopixel/eleventy --serve 
+docker build -t tampadevs .
 ```
 
-**Note:** Replace `/path-to/this-repo/on-your/disk` in the above command with the local path to your clone of the `tampadevs` repository on disk.
+And then spin up a container with a functional Eleventy environment:
+
+```
+docker run --rm -v .:/app --name tampadevs -p 8080:8080 tampadevs
+```
 
 
 ## Setting Up a Local Environment with NVM 


### PR DESCRIPTION
We were previously relying on the `femtopixel/eleventy` docker image. While this image worked fine for a while, it's been causing problems recently. Notably, it wasn't doing `npm install`

## Dockerfile changes

The main change from the `femtopixel/eleventy` Dockerfile that isn't necessarily obvious is that we're now using an officially supported [node image](https://hub.docker.com/_/node?tab=description&page=1&name=14.4-alpine) (`node:alpine3.14` → `node:alpine3.17`) as the base image

## Remaining issues

- [ ] We should pin `node` (currently `nvm` is not installed, so I'm unsure how to pin the version of node. I've confirmed both `v18.3.0` and `v20.5.1` both seem to work)
- [ ] It doesn't look like `Ctrl-C` currently kills the container for some reason, so you have to do a `docker kill` in another terminal