### PR TITLE
fix(home): Fix contributors image width on mobile

### DIFF
--- a/src/_assets/scss/_tdevs_custom.scss
+++ b/src/_assets/scss/_tdevs_custom.scss
@@ -170,3 +170,7 @@
 .contributors-cta-container {
   margin-top: 20px;
 }
+
+.open-source-contributors-image {
+  width: 100%;
+}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -73,7 +73,7 @@ layout: layouts/base.njk
     {# Github contributors #}
     <h3>Open Source Contributors</h3>
     <div class="sponsor-list sponsor-list__silver">
-      <img src="https://opencollective.com/tampadevs/contributors.svg?width=890&button=false" />
+      <img class="open-source-contributors-image" src="https://opencollective.com/tampadevs/contributors.svg?width=890&button=false" />
       <div class="sponsor-button-wrapper contributors-cta-container">
         <a class="sponsor-button td-alert-banner" href="https://github.com/TampaDevs/tampadevs">Fork This Website</a>
       </div>


### PR DESCRIPTION
- Prevent overflow of image by setting width to 100%

Fixes #51 