### PR TITLE
Fix safari mask-icon pinned tab favicon

### DIFF
--- a/src/_includes/blocks/head.njk
+++ b/src/_includes/blocks/head.njk
@@ -14,7 +14,6 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/_assets/img/favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/_assets/img/favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/_assets/img/favicon/favicon-16x16.png">
-  <link rel="mask-icon" href="/_assets/img/favicon/safari-pinned-tab.svg" color="#483ba4">
   <link rel="shortcut icon" href="/_assets/img/favicon/favicon.ico">
   <meta name="apple-mobile-web-app-title" content="{{ basics.name }}">
   <meta name="application-name" content="{{ basics.name }}">


### PR DESCRIPTION
Fixes https://github.com/TampaDevs/tampadevs/issues/171

![image](https://github.com/TampaDevs/tampadevs/assets/2068912/e70c9055-9da4-41b0-b347-b5a81feb6f39)

Note: I'm not actually sure why this works. The documentation I've seen says you need to *add* a `<link rel="mask-icon">` svg to get this to work, but this seems to work by *deleting* the mask-icon line