### PR TITLE
Update the aria labels for about and onboarding

### DIFF
--- a/src/about/index.njk
+++ b/src/about/index.njk
@@ -30,8 +30,8 @@ aos: false
         <p>Our organization strives to create unique opportunities for the local community to learn, grow, and succeed together. Whether you're a developer, student, technologist, or entrepreneur, our innovative partnerships with local Universities, non-profit tech institutes, and startup incubators mean there's something for everyone at Tampa Devs.</p>
       </div>
     </section>
-    <section aria-labelledby="event-organizers" class="td-about-section organizers container">
-      <h2 id="event-organizers">Our Team</h2>
+    <section aria-labelledby="our-team" class="td-about-section organizers container">
+      <h2 id="our-team">Our Team</h2>
       <div class="td-about-team-wrapper">
         {% for person in people | sort(false, false, 'order') %}
           {% if person.team.indexOf("Organizers") > -1 %}

--- a/src/onboarding/index.njk
+++ b/src/onboarding/index.njk
@@ -8,7 +8,7 @@ aos: false
 {% block content %}
   <main class="container main-content td-about">
    <h1>{{onboarding.title}}</h1>
-  <section aria-labelledby="event-organizers" class="td-about-section organizers container">
+  <section class="td-about-section organizers container">
   <h3>{{onboarding.description}}</h3>
  <div class="container">
   <h3>{{onboarding.step1.title}}</h3>
@@ -28,8 +28,8 @@ aos: false
 </section>
   <br></br>
 
-  <section aria-labelledby="event-organizers" class="td-about-section organizers container">
-      <h2 id="event-organizers">Current Team</h2>
+  <section aria-labelledby="current-team" class="td-about-section organizers container">
+      <h2 id="current-team">Current Team</h2>
       <div class="td-about-team-wrapper">
         {% for person in people | sort(false, false, 'order') %}
           {% if person.team.indexOf("Organizers") > -1 %}


### PR DESCRIPTION
This is so the existing arialabels and ids are consistent. Also, removed extra one that would conflict with screen readers in the onboarding page.